### PR TITLE
Optionally keep stdin open

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ The file cmdrunner.json is a JSON file that contains the configuration of comman
 
         "hiddenConsole": bool,
 
-        "killCmd": "string"
+        "killCmd": "string",
+
+        "closeStdin": bool
     }
 }
 ```
@@ -59,6 +61,8 @@ Following is a description of each attribute:
 **opts.hiddenConsole:** True indicates that output panel will not open after command execution.
 
 **opts.killCmd:** Command that will be triggered by 'Kill Commands' menu option.
+
+**opts.closeStdin:** Closes the stdin of the child processes, which will generally forc it into non-interactive mode. Defaults to true.
 
 
 

--- a/node/NodeBridgeDomain.js
+++ b/node/NodeBridgeDomain.js
@@ -161,7 +161,9 @@
         });
 
         terminal.stdin.write(cmd + '\n');
-        terminal.stdin.end();
+        if (options.closeStdin !== false) {
+            terminal.stdin.end();
+        }
     }
 
     /**


### PR DESCRIPTION
Some commands don't behave properly after `terminal.stdin.end()` is called. Make it optional.
